### PR TITLE
Handle Error on Unexpected/Force Disconnection

### DIFF
--- a/ikisocket.go
+++ b/ikisocket.go
@@ -313,7 +313,13 @@ func (kws *Websocket) disconnected(err error) {
 	}
 
 	// Close the connection from the server side
-	_ = kws.ws.Close()
+	if kws.ws.Conn != nil {
+		err = kws.ws.Close()
+
+		if err != nil {
+			kws.fireEvent(EventError, nil, err)
+		}
+	}
 
 	// fire the specific on disconnect event defined in the initial New callback
 	if kws.OnDisconnect != nil {


### PR DESCRIPTION
This commit fixes the error handling of forced/unexpected disconnection on client side to avoid server panic. 

The sample error message when having forced/unexpected disconnection:

`
Error event - Details: read tcp4 127.0.0.1:3000->127.0.0.1:58903: wsarecv: An existing connection 
was forcibly closed by the remote host.
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0xbb976b]
`

`
goroutine 44 [running]:
github.com/fasthttp/websocket.(*Conn).Close(...)
        C:/Users/GoLangDirectory/pkg/mod/github.com/fasthttp/websocket@v1.4.3/conn.go:344
github.com/antoniodipinto/ikisocket.(*Websocket).disconnected(0xc00039e150, 0xded7e0, 0xc0002b4000)
        C:/Users/GoLangDirectory/pkg/mod/github.com/antoniodipinto/ikisocket@v0.0.0-20201101094602-d230a69e97b8/ikisocket.go:316 +0x8b
github.com/antoniodipinto/ikisocket.(*Websocket).read(0xc00039e150)
        C:/Users/GoLangDirectory/pkg/mod/github.com/antoniodipinto/ikisocket@v0.0.0-20201101094602-d230a69e97b8/ikisocket.go:290 +0x1a5
created by github.com/antoniodipinto/ikisocket.(*Websocket).run
        C:/Users/GoLangDirectory/pkg/mod/github.com/antoniodipinto/ikisocket@v0.0.0-20201101094602-d230a69e97b8/ikisocket.go:244 +0x85
`

`exit status 2`