### PR TITLE
Fix timer leak

### DIFF
--- a/ikisocket.go
+++ b/ikisocket.go
@@ -442,9 +442,10 @@ func (kws *Websocket) queueLength() int {
 
 // pong writes a control message to the client
 func (kws *Websocket) pong(ctx context.Context) {
+	timeoutTicker := time.Tick(PongTimeout)
 	for {
 		select {
-		case <-time.Tick(PongTimeout):
+		case <- timeoutTicker:
 			kws.write(PongMessage, []byte{})
 		case <-ctx.Done():
 			return
@@ -509,9 +510,10 @@ func (kws *Websocket) run() {
 // Listen for incoming messages
 // and filter by message type
 func (kws *Websocket) read(ctx context.Context) {
+	timeoutTicker := time.Tick(ReadTimeout)
 	for {
 		select {
-		case <-time.Tick(ReadTimeout):
+		case <- timeoutTicker:
 			if !kws.hasConn() {
 				continue
 			}


### PR DESCRIPTION
`time.Tick` is being called from inside a for loop, this ends up creating infinite timers which over time use up a lot of CPU.
This should fix the issue by only creating one timer per loop

this is simillar to [this issue](https://github.com/paulbellamy/ratecounter/issues/9) from another repo